### PR TITLE
Prevent Exception

### DIFF
--- a/src/test/java/unl/cse/heap/HeapSortTests.java
+++ b/src/test/java/unl/cse/heap/HeapSortTests.java
@@ -31,7 +31,7 @@ public class HeapSortTests {
 	@Test
 	void heapSortFixedTest() {
 		
-		List<Integer> a = Arrays.asList(1, 6, 2, 7, 3, 8, 4, 9, 5, 10);
+		List<Integer> a = new ArrayList<>(Arrays.asList(1, 6, 2, 7, 3, 8, 4, 9, 5, 10));
 		List<Integer> b = new ArrayList<>(a);
 		HeapSort.heapSort(a, INT_CMP);
 		Collections.sort(b, INT_CMP);


### PR DESCRIPTION
Arrays.asList yields an abstract list as far as the JRE is concerned, so attempting to call methods on it results in a thrown exception unless wrapped in an ArrayList explicitly